### PR TITLE
Fix api_create_user_address return

### DIFF
--- a/simpx/client.py
+++ b/simpx/client.py
@@ -400,7 +400,8 @@ class ChatClient:
         """Create a user contact address."""
         r = await self.send_chat_command({"type": "createMyAddress"})
         if r["type"] == "userContactLinkCreated":
-            return r["connReqContact"]
+            #return r["connReqContact"]
+            return r["connLinkContact"]["connFullLink"]
         raise ChatCommandError("Error creating user address", r)
     
     async def api_delete_user_address(self) -> None:


### PR DESCRIPTION
`connReqContact` doesn't seem to be a valid key: https://github.com/simplex-chat/simplex-chat/blob/stable/bots/api/COMMANDS.md#apicreatemyaddress

This fixes it by retrieving `r["connLinkContact"]["connFullLink"]` instead

Tested it and it worked for me. The previous code caused an error.