### PR TITLE
Set accept_incognito to False to fix an error

### DIFF
--- a/simpx/profile.py
+++ b/simpx/profile.py
@@ -247,9 +247,10 @@ class ProfileManager:
             auto_reply = None
             if self.current_profile.auto_accept_message:
                 auto_reply = {"type": "text", "text": self.current_profile.auto_accept_message}
-            
+
+            # accept_incognito=True raises an exception because short addresses are automatically created and apparently not compatible. Settings accept_incognito to False still auto accept incognito profiles. If this causes a regression, please report it.
             await self.client.enable_address_auto_accept(
-                accept_incognito=True,
+                accept_incognito=False,
                 auto_reply=auto_reply
             )
         


### PR DESCRIPTION
`accept_incognito=True` raises an exception because short addresses are automatically created and apparently not compatible.

Settings accept_incognito to False still auto accept incognito profiles. If this causes a regression, please report it.

Without this change, the bot automatically crashes when starting. With this change, it seems to work fine for me.

I did not find any problem with this change with my very limited testing, but it might affect some other cases. Please be aware of this before merging, and please test yourself.

Unfortunately I didn't keep the error message. If you can't replicate with the test code provided in the README, please notify me.